### PR TITLE
fix: convert Metadataresolver file paths to match glob results

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -375,6 +375,7 @@ export class Assertions {
     const toTrack = all.filter((file) => !ignoreFiles.includes(file));
     const membersMap = new Map<string, Set<string>>();
     for (const file of toTrack) {
+      // glob will return files with '/' as separators, this won't work on Windows
       const components = this.metadataResolver.getComponentsFromPath(file.replace(/\//g, path.sep));
       for (const component of components) {
         const metadataType = component.type.name;


### PR DESCRIPTION
@W-9281900@

fixes `TypeInferenceError` when comparing windows file paths to unix results