### PR TITLE
fix: update for new RevisionCounter behavior

### DIFF
--- a/src/assertions.ts
+++ b/src/assertions.ts
@@ -329,7 +329,9 @@ export class Assertions {
       const preCommandExecution = sourceMembers.find(
         (s) => s.MemberType === sourceMember.MemberType && s.MemberName === sourceMember.MemberName
       ) || { RevisionCounter: 0 };
-      expect(sourceMember.RevisionCounter, assertionMessage).to.be.greaterThan(preCommandExecution.RevisionCounter);
+      expect(sourceMember.RevisionCounter, assertionMessage).to.be.greaterThanOrEqual(
+        preCommandExecution.RevisionCounter
+      );
     }
   }
 


### PR DESCRIPTION
According to Pablo Dias, who was in charge of server-side source tracking for the past release
>If the class or file is not updated in deploy, we don’t update SourceMember record. We did this to improve performance and some clients asked for this.

so now in practice, a sfdx force:source:deploy -m ApexClass will only update the RevisionCounter of the classes that were actually changed in that deploy, not every class included as part of that deploy

so we need to change the assertion to expect `greaterThanOrEqualTo`