### PR TITLE
fix: don't require consumer to have plugin-settings installed

### DIFF
--- a/src/testkit.ts
+++ b/src/testkit.ts
@@ -571,8 +571,10 @@ export const COMMANDS = {
 
 const getDefaultUsername = async (): Promise<string> => {
   const configVar = 'target-org';
-  const configResult = execCmd<Array<{ key?: string; name?: string; value: string }>>(`config:get ${configVar} --json`)
-    .jsonOutput?.result;
+  const configResult = execCmd<Array<{ key?: string; name?: string; value: string }>>(
+    `config:get ${configVar} --json`,
+    { ensureExitCode: 0, cli: 'sf' }
+  ).jsonOutput?.result;
   // depending on which version of config:get the user has available, there may be a name or key
   // eventually, drop the `key` option and the deprecated SfdxPropertyKeys
   const possibleKeys = [configVar, SfdxPropertyKeys.DEFAULT_USERNAME];


### PR DESCRIPTION
was calling `config:get` to get the username.

That required consumers to have plugin-settings in their devDeps/oclif.devPlugins

uses the ambient CLI instead, so as long as the NUT environment has `sf` installed this should work